### PR TITLE
add WALLET_PATH env

### DIFF
--- a/lib/commands/wallet-import-command.ts
+++ b/lib/commands/wallet-import-command.ts
@@ -8,7 +8,7 @@ import ECPairFactory from 'ecpair';
 import * as ecc from 'tiny-secp256k1';
 bitcoin.initEccLib(ecc);
 const ECPair = ECPairFactory(ecc);
-const walletPath = "wallet.json";
+const walletPath = process.env.WALLET_PATH || "wallet.json";
 
 export class WalletImportCommand implements CommandInterface {
 

--- a/lib/commands/wallet-init-command.ts
+++ b/lib/commands/wallet-init-command.ts
@@ -2,7 +2,7 @@ import { CommandResultInterface } from "./command-result.interface";
 import { CommandInterface } from "./command.interface";
 import { createPrimaryAndFundingKeyPairs } from "../utils/create-key-pair";
 import { jsonFileExists, jsonFileWriter } from "../utils/file-utils";
-const walletPath = "wallet.json";
+const walletPath = process.env.WALLET_PATH || "wallet.json";
 export class WalletInitCommand implements CommandInterface {
     async run(): Promise<CommandResultInterface> {
         if (await this.walletExists()) {

--- a/lib/utils/validate-wallet-storage.ts
+++ b/lib/utils/validate-wallet-storage.ts
@@ -11,7 +11,7 @@ import { jsonFileReader } from './file-utils';
 import { toXOnly } from './create-key-pair';
 const bip32 = BIP32Factory(ecc);
 
-const WALLET_FILE = "wallet.json";
+const WALLET_FILE = process.env.WALLET_PATH || "wallet.json";
 
 
 export interface IWalletRecord {


### PR DESCRIPTION
Add an optional `WALLET_PATH` env, thus we can manage multiple wallets easily.

The `cli` commands will be this:

```bash
WALLET_PATH=path-to-wallet.json yarn cli [commands]
```