### PR TITLE
Allow insecure rpc

### DIFF
--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -15,7 +15,10 @@ export class ElectrumApi implements ElectrumApiInterface {
     }
 
     public async resetConnection() {
-        this.ws = new WebSocket(this.url);
+        this.ws = new WebSocket(
+            this.url,
+	    { rejectUnauthorized: process.env.ALLOW_INSECURE_RPC !== 'true' }
+        );
         //this.open();
     }
 

--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -17,7 +17,7 @@ export class ElectrumApi implements ElectrumApiInterface {
     public async resetConnection() {
         this.ws = new WebSocket(
             this.url,
-	    { rejectUnauthorized: process.env.ALLOW_INSECURE_RPC !== 'true' }
+            { rejectUnauthorized: process.env.ALLOW_INSECURE_RPC !== 'true' }
         );
         //this.open();
     }


### PR DESCRIPTION
When using a local `ElectrumX` server, normally we deployed the server using self-signed certificates.

Then the WebSocket connection will be failed.

With this change, we can use following command to avoid this:

```bash
ALLOW_INSECURE_RPC=true yarn cli server-version
```