### PR TITLE
Add phrase and path options to wallet-init. Fix subrealm mint to not send parent

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -228,9 +228,11 @@ program.command('wallet-decode')
 
 program.command('wallet-init')
   .description('Initializes a new wallet at wallet.json')
+  .option('--phrase <string>', 'Provide a wallet phrase')
+  .option('--path <string>', 'Provide a path base', `m/86'/0'/0'`)
   .action(async (options) => {
     try {
-      const result = await Atomicals.walletInit();
+      const result = await Atomicals.walletInit(options.phrase, options.path);
       console.log('Wallet created at wallet.json');
       console.log(`phrase: ${result.data.phrase}`);
       console.log(`Primary address (P2TR): ${result.data.primary.address}`);

--- a/lib/commands/mint-interactive-subrealm-direct-command.ts
+++ b/lib/commands/mint-interactive-subrealm-direct-command.ts
@@ -103,6 +103,13 @@ export class MintInteractiveSubrealmDirectCommand implements CommandInterface {
 
     // For direct mints we must spent the parent realm atomical in the same transaction
     atomicalBuilder.addInputUtxo(utxoLocation, this.owner.WIF)
+    
+    // The first output will be the location of the subrealm minted
+    atomicalBuilder.addOutput({
+      address: this.address,
+      value: this.options.satsoutput as number,
+    });
+
     // ... and make sure to assign an output to capture the spent parent realm atomical
     atomicalBuilder.addOutput({
       address: utxoLocation.address,

--- a/lib/commands/wallet-init-command.ts
+++ b/lib/commands/wallet-init-command.ts
@@ -7,11 +7,15 @@ import { walletPathResolver } from "../utils/wallet-path-resolver";
 const walletPath = walletPathResolver();
 
 export class WalletInitCommand implements CommandInterface {
+    constructor(private phrase: string | undefined, private path: string) {
+
+    }
     async run(): Promise<CommandResultInterface> {
         if (await this.walletExists()) {
             throw "wallet.json exists, please remove it first to initialize another wallet. You may also use 'wallet-create' command to generate a new wallet."
         }
-        const wallet = await createPrimaryAndFundingKeyPairs();
+
+        const wallet = await createPrimaryAndFundingKeyPairs(this.phrase, this.path);
 
         await jsonFileWriter(walletPath, {
             phrase: wallet.phrase,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -128,9 +128,9 @@ export class Atomicals implements APIInterface {
     }
   }
 
-  static async walletInit(): Promise<any> {
+  static async walletInit(phrase: string | undefined, path: string): Promise<any> {
     try {
-      const command: CommandInterface = new WalletInitCommand();
+      const command: CommandInterface = new WalletInitCommand(phrase, path);
       return command.run();
     } catch (error: any) {
       return {

--- a/lib/utils/create-key-pair.ts
+++ b/lib/utils/create-key-pair.ts
@@ -56,13 +56,20 @@ export const createKeyPair = async (phrase: string = '', path = `m/44'/0'/0'/0/0
     }
 }
 
-export const createPrimaryAndFundingKeyPairs = async () => {
-    const phraseResult = await createMnemonicPhrase();
-
+export const createPrimaryAndFundingKeyPairs = async (phrase?: string | undefined, path?: string | undefined) => {
+    let phraseResult: any = phrase;
+    if (!phraseResult) {
+        phraseResult = await createMnemonicPhrase();
+        phraseResult = phraseResult.phrase;
+    }
+    let pathUsed = `m/44'/0'/0'`;
+    if (path) {
+        pathUsed = path;
+    }
     return {
-        phrase: phraseResult.phrase,
-        primary: await createKeyPair(phraseResult.phrase, `m/44'/0'/0'/0/0`),
-        funding: await createKeyPair(phraseResult.phrase, `m/44'/0'/0'/1/0`)
+        phrase: phraseResult,
+        primary: await createKeyPair(phraseResult, `${pathUsed}/0/0`),
+        funding: await createKeyPair(phraseResult, `${pathUsed}/1/0`)
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomicals-js",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Atomicals Javascript Library and CLI - atomicals.xyz",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Critical update:

Add phrase and path options to wallet-init. 
Fix subrealm mint to not send parent

