### PR TITLE
fixed Crockford's Base32 alphabet, remove character 'u'.

### DIFF
--- a/lib/utils/atomical-format-helpers.ts
+++ b/lib/utils/atomical-format-helpers.ts
@@ -313,7 +313,7 @@ export function decodePayloadCBOR(payload: any, hexify = true, addUtf8 = false):
 const errMessage = 'Invalid --bitwork value. Must be hex with a single optional . dot separated with a number of 1 to 15 with no more than 10 hex characters. Example: 0123 or 3456.12';
 
 export const isBitworkRefBase32Prefix = (bitwork): string | null => {
-  if (/^[abcdefghjkmnpqrstuvwxyz0-9]{1,10}$/.test(bitwork)) {
+  if (/^[abcdefghjkmnpqrstvwxyz0-9]{1,10}$/.test(bitwork)) {
     const enc = CrockfordBase32.CrockfordBase32.decode(bitwork);
     return enc.toString('hex').toLowerCase();
   }


### PR DESCRIPTION
Base on https://www.crockford.com/base32.html, fixed Crockford's Base32 alphabet, remove character 'u'.