### PR TITLE
Remove unused cli command parameter

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -847,7 +847,7 @@ program.command('find-containers')
   .description('Search containers')
   .option('--q <string>', 'Search query')
   .option('--asc <string>', 'Sort by ascending', 'true')
-  .action(async (prefix, options) => {
+  .action(async (options) => {
     try {
       await validateWalletStorage();
       const config: ConfigurationInterface = validateCliInputs();


### PR DESCRIPTION
There's a parameter in find-containers command never used, --q and --asc can not accept by options