### PR TITLE
Multiple improvements to the `ElectrumApi`

### DIFF
--- a/lib/api/electrum-api.interface.ts
+++ b/lib/api/electrum-api.interface.ts
@@ -15,7 +15,7 @@ export interface ElectrumApiInterface {
     sendTransaction: (rawtx: string) => Promise<string>;
     getUnspentAddress: (address: string) => Promise<IUnspentResponse>;
     getUnspentScripthash: (address: string) => Promise<IUnspentResponse>;
-    waitUntilUTXO: (address: string, satoshis: number, sleepTimeSec: number, exactSatoshiAmount?: boolean) => Promise<any>;
+    waitUntilUTXO: (address: string, satoshis: number, sleepTimeSec: number, exactSatoshiAmount?: boolean) => Promise<UTXO>;
     getTx: (txid: string, verbose?: boolean) => Promise<any>;
     serverVersion: () => Promise<any>;
     broadcast: (rawtx: string, force?: boolean) => Promise<any>;

--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -13,85 +13,75 @@ export class ElectrumApi implements ElectrumApiInterface {
     }
 
     public async resetConnection() {
-    
+
     }
 
     static createClient(url: string, usePost = true) {
         return new ElectrumApi(url, usePost);
     }
 
-    public async open(): Promise<any> {
-        const p = new Promise((resolve, reject) => {
+    public open(): Promise<any> {
+        return new Promise((resolve) => {
             if (this.isOpenFlag) {
                 resolve(true);
                 return;
             }
             resolve(true);
         });
-        return p;
     }
 
     public isOpen(): boolean {
         return this.isOpenFlag;
     }
 
-    public async close(): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            resolve(true);
-        });
-        return p;
+    public close(): Promise<any> {
+        return Promise.resolve(true);
     }
 
     public async call(method, params) {
-        if (this.usePost) {
-            const response = await axios.post(this.baseUrl + '/' + method, { params} );
+        try {
+            let response: AxiosResponse<any, any>;
+            if (this.usePost) {
+                response = await axios.post(`${this.baseUrl}/${method}`, {params});
+            } else {
+                response = await axios.get(`${this.baseUrl}/${method}?params=${JSON.stringify(params)}`);
+            }
             return response.data.response;
-        } else {
-            const response = await axios.get(this.baseUrl + '/' + method + '?params=' + JSON.stringify(params));
-            return response.data.response;
+        } catch (error) {
+            console.log(error);
+            throw error;
         }
     }
 
-    public async sendTransaction(signedRawtx: string): Promise<any> {
-       return this.broadcast(signedRawtx);
+    public sendTransaction(signedRawTx: string): Promise<any> {
+       return this.broadcast(signedRawTx);
     }
 
-    public async getTx(txid: string, verbose = false): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.transaction.get', [txid, verbose ? 1 : 0]).then(function (result: any) {
-                resolve({
-                    success: true,
-                    tx: result
-                });
-            }).catch((error) => {
-                reject(error);
-            })
+    public getTx(txId: string, verbose = false): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.transaction.get', [txId, verbose ? 1 : 0]
+            ).then((result: any) => {
+                resolve({success: true, tx: result});
+            }).catch(reject)
         });
-        return p;
     }
 
-    public async getUnspentAddress(address: string): Promise<IUnspentResponse | any> {
+    public getUnspentAddress(address: string): Promise<IUnspentResponse | any> {
         const { scripthash } = detectAddressTypeToScripthash(address)
         return this.getUnspentScripthash(scripthash)
     }
 
-    public async getUnspentScripthash(scripthash: string): Promise<IUnspentResponse | any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.scripthash.listunspent', [scripthash]).then(function (result: any) {
-                const data = {
-                    unconfirmed: 0,
-                    confirmed: 0,
-                    //balance: 0,
-                    utxos: [] as UTXO[]
-                };
-
+    public getUnspentScripthash(scriptHash: string): Promise<IUnspentResponse | any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.scripthash.listunspent', [scriptHash]).then(function (result: any) {
+                const data = {unconfirmed: 0, confirmed: 0, utxos: [] as UTXO[]};
                 for (const utxo of result) {
                     if (!utxo.height || utxo.height <= 0) {
                         data.unconfirmed += utxo.value;
                     } else {
                         data.confirmed += utxo.value;
                     }
-                    //data.balance += utxo.value;
+                    // data.balance += utxo.value;
                     data.utxos.push({
                         txid: utxo.tx_hash,
                         txId: utxo.tx_hash,
@@ -101,16 +91,12 @@ export class ElectrumApi implements ElectrumApiInterface {
                         vout: utxo.tx_pos,
                         value: utxo.value,
                         atomicals: utxo.atomicals,
-                        //script: addressToP2PKH(address)
+                        // script: addressToP2PKH(address)
                     })
                 }
                 resolve(data);
-            }).catch((error) => {
-                reject(error);
-            })
-
+            }).catch(reject)
         });
-        return p;
     }
 
     async waitUntilUTXO(address: string, satoshis: number, intervalSeconds = 10, exactSatoshiAmount = false): Promise<UTXO> {
@@ -161,308 +147,164 @@ export class ElectrumApi implements ElectrumApiInterface {
         });
     }
 
-    public async serverVersion(): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('server.version', []).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                reject(error);
-            })
+    public serverVersion(): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('server.version', []).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async broadcast(rawtx: string, force = false): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            if (force) {
-                this.call('blockchain.transaction.broadcast_force', [rawtx]).then(function (result: any) {
-                    resolve(result);
-                }).catch((error) => {
-                    console.log(error)
-                    reject(error);
-                })
-            } else {
-                this.call('blockchain.transaction.broadcast', [rawtx]).then(function (result: any) {
-                    resolve(result);
-                }).catch((error) => {
-                    console.log(error)
-                    reject(error);
-                })
-            }
-
+    public broadcast(rawtx: string, force = false): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call(
+                force
+                    ? 'blockchain.transaction.broadcast_force'
+                    : 'blockchain.transaction.broadcast',
+                [rawtx],
+            ).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async dump(): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.dump', [ ]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public dump(): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.dump', []).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetGlobal(hashes: number): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_global', [ hashes ]).then(function (result: any) {
-                console.log('response', result)
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetGlobal(hashes: number): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_global', [hashes]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGet(atomicalAliasOrId: string | number): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get', [atomicalAliasOrId]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGet(atomicalAliasOrId: string | number): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get', [atomicalAliasOrId]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetFtInfo(atomicalAliasOrId: string | number): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_ft_info', [atomicalAliasOrId]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetFtInfo(atomicalAliasOrId: string | number): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_ft_info', [atomicalAliasOrId]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetLocation(atomicalAliasOrId: string | number): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_location', [atomicalAliasOrId]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetLocation(atomicalAliasOrId: string | number): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_location', [atomicalAliasOrId]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetStateHistory(atomicalAliasOrId: string | number): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_state_history', [atomicalAliasOrId]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetStateHistory(atomicalAliasOrId: string | number): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_state_history', [atomicalAliasOrId]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetState(atomicalAliasOrId: string | number, verbose: boolean): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_state', [atomicalAliasOrId, verbose ? 1 : 0]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetState(atomicalAliasOrId: string | number, verbose: boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_state', [atomicalAliasOrId, verbose ? 1 : 0]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetEventHistory(atomicalAliasOrId: string | number): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_events', [atomicalAliasOrId]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetEventHistory(atomicalAliasOrId: string | number): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_events', [atomicalAliasOrId]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetTxHistory(atomicalAliasOrId: string | number): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_tx_history', [atomicalAliasOrId]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetTxHistory(atomicalAliasOrId: string | number): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_tx_history', [atomicalAliasOrId]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async history(scripthash: string): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.scripthash.get_history', [scripthash]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public history(scripthash: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.scripthash.get_history', [scripthash]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsList(limit: number, offset: number, asc = false): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.list', [limit, offset, asc ? 1 : 0]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsList(limit: number, offset: number, asc = false): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.list', [limit, offset, asc ? 1 : 0]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsByScripthash(scripthash: string, verbose = true): Promise<any> {
-        const p = new Promise((resolve, reject) => {
+    public atomicalsByScripthash(scripthash: string, verbose = true): Promise<any> {
+        return new Promise((resolve, reject) => {
             const params: any[] = [scripthash];
             if (verbose) {
                 params.push(true)
             }
-            this.call('blockchain.atomicals.listscripthash', params).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+            this.call('blockchain.atomicals.listscripthash', params).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsByAddress(address: string): Promise<any> {
+    public atomicalsByAddress(address: string): Promise<any> {
         const { scripthash } = detectAddressTypeToScripthash(address);
         return this.atomicalsByScripthash(scripthash)
     }
 
-    public async atomicalsAtLocation(location: string): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.at_location', [location]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsAtLocation(location: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.at_location', [location]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async txs(txs: string[], verbose: boolean): Promise<any> {
-        let p;
-        if (true) {
-            p = []
-            for (const tx of txs) {
-                p.push(new Promise((resolve, reject) => {
-                    this.call('blockchain.transaction.get', [tx, verbose ? 1 : 0]).then(function (result: any) {
-                        resolve(result);
-                    }).catch((error) => {
-                        console.log('error ', error)
-                        reject(error);
-                    })
-                }))
-            }
-            return Promise.all(p);
-        }
+    public txs(txs: string[], verbose: boolean): Promise<any> {
+        return Promise.all(
+            txs.map((tx) => new Promise((resolve, reject) => {
+                this.call('blockchain.transaction.get', [tx, verbose ? 1 : 0]).then(resolve).catch(reject)
+            }))
+        );
     }
 
-    public async atomicalsGetRealmInfo(realmOrSubRealm: string, verbose?: boolean): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_realm_info', [realmOrSubRealm, verbose ? 1 : 0]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetRealmInfo(realmOrSubRealm: string, verbose?: boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_realm_info', [realmOrSubRealm, verbose ? 1 : 0]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetByRealm(realm: string): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_by_realm', [realm]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetByRealm(realm: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_by_realm', [realm]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetByTicker(ticker: string): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_by_ticker', [ticker]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetByTicker(ticker: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_by_ticker', [ticker]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetByContainer(container: string): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_by_container', [container]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetByContainer(container: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_by_container', [container]).then(resolve).catch(reject)
         });
-        return p;
     }
-    public async atomicalsGetContainerItems(container: string, limit: number, offset: number): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_container_items', [container, limit, offset]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetContainerItems(container: string, limit: number, offset: number): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_container_items', [container, limit, offset]).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsGetByContainerItem(container: string, itemName: string): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_by_container_item', [container, itemName]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+    public atomicalsGetByContainerItem(container: string, itemName: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call('blockchain.atomicals.get_by_container_item', [container, itemName]).then(resolve).catch(reject)
         });
-        return p;
-    }
- 
-    public async atomicalsGetByContainerItemValidated(container: string, item: string, bitworkc: string, bitworkr: string, main: string, mainHash: string, proof: any, checkWithoutSealed: boolean): Promise<any> {
-        const p = new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_by_container_item_validate', [container, item, bitworkc, bitworkr, main, mainHash, proof, checkWithoutSealed]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
-        });
-        return p;
     }
 
-    public async atomicalsFindTickers(prefix: string | null, asc?: boolean): Promise<any> {
-        const p = new Promise((resolve, reject) => {
+    public atomicalsGetByContainerItemValidated(container: string, item: string, bitworkc: string, bitworkr: string, main: string, mainHash: string, proof: any, checkWithoutSealed: boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.call(
+                'blockchain.atomicals.get_by_container_item_validate',
+                [container, item, bitworkc, bitworkr, main, mainHash, proof, checkWithoutSealed]
+            ).then(resolve).catch(reject)
+        });
+    }
+
+    public atomicalsFindTickers(prefix: string | null, asc?: boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
             const args: any = []
             args.push(prefix ? prefix : null)
             if (!asc) {
@@ -470,18 +312,12 @@ export class ElectrumApi implements ElectrumApiInterface {
             } else {
                 args.push(0)
             }
-            this.call('blockchain.atomicals.find_tickers', args).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+            this.call('blockchain.atomicals.find_tickers', args).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsFindContainers(prefix: string | null, asc?: boolean): Promise<any> {
-        const p = new Promise((resolve, reject) => {
+    public atomicalsFindContainers(prefix: string | null, asc?: boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
             const args: any = []
             args.push(prefix ? prefix : null)
             if (!asc) {
@@ -489,18 +325,12 @@ export class ElectrumApi implements ElectrumApiInterface {
             } else {
                 args.push(0)
             }
-            this.call('blockchain.atomicals.find_containers', args).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+            this.call('blockchain.atomicals.find_containers', args).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsFindRealms(prefix: string | null, asc?: boolean): Promise<any> {
-        const p = new Promise((resolve, reject) => {
+    public atomicalsFindRealms(prefix: string | null, asc?: boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
             const args: any = []
             args.push(prefix ? prefix : null)
             if (!asc) {
@@ -508,18 +338,12 @@ export class ElectrumApi implements ElectrumApiInterface {
             } else {
                 args.push(0)
             }
-            this.call('blockchain.atomicals.find_realms', args).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+            this.call('blockchain.atomicals.find_realms', args).then(resolve).catch(reject)
         });
-        return p;
     }
 
-    public async atomicalsFindSubRealms(parentRealmId: string, prefix: string | null, asc?: boolean): Promise<any> {
-        const p = new Promise((resolve, reject) => {
+    public atomicalsFindSubRealms(parentRealmId: string, prefix: string | null, asc?: boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
             const args: any = []
             args.push(prefix ? prefix : null)
             if (!asc) {
@@ -527,13 +351,7 @@ export class ElectrumApi implements ElectrumApiInterface {
             } else {
                 args.push(0)
             }
-            this.call('blockchain.atomicals.find_subrealms', [parentRealmId, args]).then(function (result: any) {
-                resolve(result);
-            }).catch((error) => {
-                console.log('error ', error)
-                reject(error);
-            })
+            this.call('blockchain.atomicals.find_subrealms', [parentRealmId, args]).then(resolve).catch(reject)
         });
-        return p;
     }
 }

--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -16,8 +16,8 @@ export class ElectrumApi implements ElectrumApiInterface {
     
     }
 
-    static createClient(url: string) {
-        return new ElectrumApi(url);
+    static createClient(url: string, usePost = true) {
+        return new ElectrumApi(url, usePost);
     }
 
     public async open(): Promise<any> {

--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -115,7 +115,7 @@ export class ElectrumApi implements ElectrumApiInterface {
                         console.error(e);
                         return {unconfirmed: 0, confirmed: 0, utxos: []};
                     });
-                    const utxos = response.utxos;
+                    const utxos = response.utxos.sort((a, b) => a.value - b.value);
                     for (const utxo of utxos) {
                         // Do not use utxos that have attached atomicals
                         if (hasAttachedAtomicals(utxo)) {

--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -54,7 +54,7 @@ export class ElectrumApi implements ElectrumApiInterface {
     }
 
     public sendTransaction(signedRawTx: string): Promise<any> {
-       return this.broadcast(signedRawTx);
+        return this.broadcast(signedRawTx);
     }
 
     public getTx(txId: string, verbose = false): Promise<any> {
@@ -62,12 +62,12 @@ export class ElectrumApi implements ElectrumApiInterface {
             this.call('blockchain.transaction.get', [txId, verbose ? 1 : 0]
             ).then((result: any) => {
                 resolve({success: true, tx: result});
-            }).catch(reject)
+            }).catch((error) => reject(error))
         });
     }
 
     public getUnspentAddress(address: string): Promise<IUnspentResponse | any> {
-        const { scripthash } = detectAddressTypeToScripthash(address)
+        const {scripthash} = detectAddressTypeToScripthash(address)
         return this.getUnspentScripthash(scripthash)
     }
 
@@ -95,7 +95,7 @@ export class ElectrumApi implements ElectrumApiInterface {
                     })
                 }
                 resolve(data);
-            }).catch(reject)
+            }).catch((error) => reject(error))
         });
     }
 
@@ -148,96 +148,68 @@ export class ElectrumApi implements ElectrumApiInterface {
     }
 
     public serverVersion(): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('server.version', []).then(resolve).catch(reject)
-        });
+        return this.call('server.version', []);
     }
 
     public broadcast(rawtx: string, force = false): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call(
-                force
-                    ? 'blockchain.transaction.broadcast_force'
-                    : 'blockchain.transaction.broadcast',
-                [rawtx],
-            ).then(resolve).catch(reject)
-        });
+        return this.call(
+            force
+                ? 'blockchain.transaction.broadcast_force'
+                : 'blockchain.transaction.broadcast',
+            [rawtx],
+        );
     }
 
     public dump(): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.dump', []).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.dump', []);
     }
 
     public atomicalsGetGlobal(hashes: number): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_global', [hashes]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_global', [hashes]);
     }
 
     public atomicalsGet(atomicalAliasOrId: string | number): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get', [atomicalAliasOrId]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get', [atomicalAliasOrId]);
     }
 
     public atomicalsGetFtInfo(atomicalAliasOrId: string | number): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_ft_info', [atomicalAliasOrId]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_ft_info', [atomicalAliasOrId]);
     }
 
     public atomicalsGetLocation(atomicalAliasOrId: string | number): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_location', [atomicalAliasOrId]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_location', [atomicalAliasOrId]);
     }
 
     public atomicalsGetStateHistory(atomicalAliasOrId: string | number): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_state_history', [atomicalAliasOrId]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_state_history', [atomicalAliasOrId]);
     }
 
     public atomicalsGetState(atomicalAliasOrId: string | number, verbose: boolean): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_state', [atomicalAliasOrId, verbose ? 1 : 0]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_state', [atomicalAliasOrId, verbose ? 1 : 0]);
     }
 
     public atomicalsGetEventHistory(atomicalAliasOrId: string | number): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_events', [atomicalAliasOrId]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_events', [atomicalAliasOrId]);
     }
 
     public atomicalsGetTxHistory(atomicalAliasOrId: string | number): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_tx_history', [atomicalAliasOrId]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_tx_history', [atomicalAliasOrId]);
     }
 
     public history(scripthash: string): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.scripthash.get_history', [scripthash]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.scripthash.get_history', [scripthash]);
     }
 
     public atomicalsList(limit: number, offset: number, asc = false): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.list', [limit, offset, asc ? 1 : 0]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.list', [limit, offset, asc ? 1 : 0]);
     }
 
     public atomicalsByScripthash(scripthash: string, verbose = true): Promise<any> {
-        return new Promise((resolve, reject) => {
-            const params: any[] = [scripthash];
-            if (verbose) {
-                params.push(true)
-            }
-            this.call('blockchain.atomicals.listscripthash', params).then(resolve).catch(reject)
-        });
+        const params: any[] = [scripthash];
+        if (verbose) {
+            params.push(true);
+        }
+        return this.call('blockchain.atomicals.listscripthash', params);
     }
 
     public atomicalsByAddress(address: string): Promise<any> {
@@ -246,112 +218,87 @@ export class ElectrumApi implements ElectrumApiInterface {
     }
 
     public atomicalsAtLocation(location: string): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.at_location', [location]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.at_location', [location]);
     }
 
     public txs(txs: string[], verbose: boolean): Promise<any> {
         return Promise.all(
-            txs.map((tx) => new Promise((resolve, reject) => {
-                this.call('blockchain.transaction.get', [tx, verbose ? 1 : 0]).then(resolve).catch(reject)
-            }))
+            txs.map((tx) => this.call('blockchain.transaction.get', [tx, verbose ? 1 : 0]))
         );
     }
 
     public atomicalsGetRealmInfo(realmOrSubRealm: string, verbose?: boolean): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_realm_info', [realmOrSubRealm, verbose ? 1 : 0]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_realm_info', [realmOrSubRealm, verbose ? 1 : 0]);
     }
 
     public atomicalsGetByRealm(realm: string): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_by_realm', [realm]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_by_realm', [realm]);
     }
 
     public atomicalsGetByTicker(ticker: string): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_by_ticker', [ticker]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_by_ticker', [ticker]);
     }
 
     public atomicalsGetByContainer(container: string): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_by_container', [container]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_by_container', [container]);
     }
+
     public atomicalsGetContainerItems(container: string, limit: number, offset: number): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_container_items', [container, limit, offset]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_container_items', [container, limit, offset]);
     }
 
     public atomicalsGetByContainerItem(container: string, itemName: string): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call('blockchain.atomicals.get_by_container_item', [container, itemName]).then(resolve).catch(reject)
-        });
+        return this.call('blockchain.atomicals.get_by_container_item', [container, itemName]);
     }
 
     public atomicalsGetByContainerItemValidated(container: string, item: string, bitworkc: string, bitworkr: string, main: string, mainHash: string, proof: any, checkWithoutSealed: boolean): Promise<any> {
-        return new Promise((resolve, reject) => {
-            this.call(
-                'blockchain.atomicals.get_by_container_item_validate',
-                [container, item, bitworkc, bitworkr, main, mainHash, proof, checkWithoutSealed]
-            ).then(resolve).catch(reject)
-        });
+        return this.call(
+            'blockchain.atomicals.get_by_container_item_validate',
+            [container, item, bitworkc, bitworkr, main, mainHash, proof, checkWithoutSealed],
+        );
     }
 
     public atomicalsFindTickers(prefix: string | null, asc?: boolean): Promise<any> {
-        return new Promise((resolve, reject) => {
-            const args: any = []
-            args.push(prefix ? prefix : null)
-            if (!asc) {
-                args.push(1)
-            } else {
-                args.push(0)
-            }
-            this.call('blockchain.atomicals.find_tickers', args).then(resolve).catch(reject)
-        });
+        const args: any = []
+        args.push(prefix ? prefix : null)
+        if (!asc) {
+            args.push(1)
+        } else {
+            args.push(0)
+        }
+        return this.call('blockchain.atomicals.find_tickers', args);
     }
 
     public atomicalsFindContainers(prefix: string | null, asc?: boolean): Promise<any> {
-        return new Promise((resolve, reject) => {
-            const args: any = []
-            args.push(prefix ? prefix : null)
-            if (!asc) {
-                args.push(1)
-            } else {
-                args.push(0)
-            }
-            this.call('blockchain.atomicals.find_containers', args).then(resolve).catch(reject)
-        });
+        const args: any = []
+        args.push(prefix ? prefix : null)
+        if (!asc) {
+            args.push(1)
+        } else {
+            args.push(0)
+        }
+        return this.call('blockchain.atomicals.find_containers', args);
     }
 
     public atomicalsFindRealms(prefix: string | null, asc?: boolean): Promise<any> {
-        return new Promise((resolve, reject) => {
-            const args: any = []
-            args.push(prefix ? prefix : null)
-            if (!asc) {
-                args.push(1)
-            } else {
-                args.push(0)
-            }
-            this.call('blockchain.atomicals.find_realms', args).then(resolve).catch(reject)
-        });
+        const args: any = []
+        args.push(prefix ? prefix : null)
+        if (!asc) {
+            args.push(1)
+        } else {
+            args.push(0)
+        }
+        return this.call('blockchain.atomicals.find_realms', args);
     }
 
     public atomicalsFindSubRealms(parentRealmId: string, prefix: string | null, asc?: boolean): Promise<any> {
-        return new Promise((resolve, reject) => {
-            const args: any = []
-            args.push(prefix ? prefix : null)
-            if (!asc) {
-                args.push(1)
-            } else {
-                args.push(0)
-            }
-            this.call('blockchain.atomicals.find_subrealms', [parentRealmId, args]).then(resolve).catch(reject)
-        });
+        const args: any = []
+        args.push(prefix ? prefix : null)
+        if (!asc) {
+            args.push(1)
+        } else {
+            args.push(0)
+        }
+        return this.call('blockchain.atomicals.find_subrealms', [parentRealmId, args]);
     }
 }

--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable prettier/prettier */
-import { detectAddressTypeToScripthash } from "../utils/address-helpers"
-import { UTXO } from "../types/UTXO.interface"
+import axios, { AxiosResponse } from 'axios';
 import { ElectrumApiInterface, IUnspentResponse } from "./electrum-api.interface";
-import axios from 'axios';
+import { UTXO } from "../types/UTXO.interface"
+import { detectAddressTypeToScripthash } from "../utils/address-helpers"
 
 export class ElectrumApi implements ElectrumApiInterface {
     private isOpenFlag = false;
@@ -113,19 +113,14 @@ export class ElectrumApi implements ElectrumApiInterface {
         return p;
     }
 
-    async waitUntilUTXO(address: string, satoshis: number, intervalSeconds = 10, exactSatoshiAmount = false): Promise<any> {
-
+    async waitUntilUTXO(address: string, satoshis: number, intervalSeconds = 10, exactSatoshiAmount = false): Promise<UTXO> {
         function hasAttachedAtomicals(utxo): any | null {
             if (utxo && utxo.atomicals && utxo.atomicals.length) {
                 return true;
             }
-            if (utxo && utxo.height <= 0) {
-                return true;
-            }
-            return false;
+            return utxo && utxo.height <= 0;
         }
-
-        return new Promise<any[]>((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             let intervalId: any;
             const checkForUtxo = async () => {
                 console.log('...');


### PR DESCRIPTION
- Sort UTXOs in asc, use the smallest UTXO first.
- Allow `usePost` argument in `ElectrumApi.createClient`.