### PR TITLE
fix the bug causing unnecessary gas fee increases

### DIFF
--- a/lib/utils/atomical-operation-builder.ts
+++ b/lib/utils/atomical-operation-builder.ts
@@ -897,7 +897,7 @@ export class AtomicalOperationBuilder {
     */
     addCommitChangeOutputIfRequired(extraInputValue: number, fee: FeeCalculations, pbst: any, address: string) {
         const totalInputsValue = extraInputValue + this.getTotalAdditionalInputValues();
-        const totalOutputsValue = this.getTotalAdditionalOutputValues() + fee.revealFeePlusOutputs;
+        const totalOutputsValue = fee.revealFeePlusOutputs;
         const calculatedFee = totalInputsValue - totalOutputsValue;
         // It will be invalid, but at least we know we don't need to add change
         if (calculatedFee <= 0) {


### PR DESCRIPTION
Issue: When mining FT and NFT, the setting of the satsbyte parameter is ineffective, and the actual gas fee paid is always higher than the set value, sometimes even up to 10 times higher, for example, when mining electron, the gas fee is 22.67U: https://www.blockchain.com/explorer/transactions/btc/1840000a132746b15ff545c075fe12e55ba69f1ffa57856a3bddf21f684a2c38).

Cause: When sending the commit transaction, unnecessary additional fees (this.getTotalAdditionalOutputValues()) are added in the AtomicalOperationBuilder::addCommitChangeOutputIfRequired method while obtaining the fee for the reveal transaction. In fact, this portion of the fee is already included in revealFeePlusOutputs and should not be added again.
![image](https://github.com/atomicals/atomicals-js/assets/3832817/72a8c540-c2f2-429a-a3fc-bbb3ee0c04cb)

Solution: Modify "const totalOutputsValue = this.getTotalAdditionalOutputValues() + fee.revealFeePlusOutputs;" to "const totalOutputsValue = fee.revealFeePlusOutputs;"

Has it been tested: Yes, transaction for mining electron has been tested below.
Gas fee becomes 1.49U when mint electron now: https://www.blockchain.com/explorer/transactions/btc/1840000b56f0a8a9fed31753dfa29fad00048d9b0905dd770f7929e888e3419b