### PR TITLE
Fix unnecessary Transaction::getId() caculation

### DIFF
--- a/lib/utils/atomical-operation-builder.ts
+++ b/lib/utils/atomical-operation-builder.ts
@@ -565,16 +565,16 @@ export class AtomicalOperationBuilder {
                     process.stdout.clearLine(0);
                     process.stdout.cursorTo(0);
                     process.stdout.write(chalk.green(checkTxid, ` nonces: ${noncesGenerated} (${nonce})`));
-                    console.log('\nBitwork matches commit txid! ', prelimTx.getId(), `@ time: ${unixtime}`)
+                    console.log('\nBitwork matches commit txid! ', checkTxid, `@ time: ${unixtime}`)
                     // We found a solution, therefore broadcast it 
                     const interTx = psbtStart.extractTransaction();
                     const rawtx = interTx.toHex();
                     AtomicalOperationBuilder.finalSafetyCheckForExcessiveFee(psbtStart, interTx);
                     if (!(await this.broadcastWithRetries(rawtx))) {
-                        console.log('Error sending', prelimTx.getId(), rawtx);
-                        throw new Error('Unable to broadcast commit transaction after attempts: ' + prelimTx.getId());
+                        console.log('Error sending', checkTxid, rawtx);
+                        throw new Error('Unable to broadcast commit transaction after attempts: ' + checkTxid);
                     } else {
-                        console.log('Success sent tx: ', prelimTx.getId());
+                        console.log('Success sent tx: ', checkTxid);
                     }
                     commitMinedWithBitwork = true;
                     performBitworkForCommitTx = false;


### PR DESCRIPTION
Every time the `getId` function is invoked, it processes calculations based on the raw transaction data. However, since the `checkTxid` has already been obtained earlier, it's more efficient to utilize that instead.

https://github.com/bitcoinjs/bitcoinjs-lib/blob/1f92ada3fda587c1c0a6aa93649afa04e8382b93/ts_src/transaction.ts#L597-L600