### PR TITLE
enhance type secure in select-funding-utxo

### DIFF
--- a/lib/types/UTXO.interface.ts
+++ b/lib/types/UTXO.interface.ts
@@ -9,6 +9,7 @@ export interface UTXO {
   outputIndex: number;
   atomicals?: any[];
   atomicals_at_location?: any[];
+  nonWitnessUtxo?: Buffer;
 }
 
 export interface BalanceData {

--- a/lib/utils/select-funding-utxo.ts
+++ b/lib/utils/select-funding-utxo.ts
@@ -1,19 +1,20 @@
 import { ElectrumApiInterface } from "../api/electrum-api.interface";
-const bitcoin = require('bitcoinjs-lib');
+import { type UTXO } from "../types/UTXO.interface";
+import * as bitcoin from 'bitcoinjs-lib';
 import ECPairFactory from 'ecpair';
 import * as ecc from 'tiny-secp256k1';
 import * as qrcode from 'qrcode-terminal';
 bitcoin.initEccLib(ecc);
 const ECPair = ECPairFactory(ecc);
 
-export const getInputUtxoFromTxid = async (utxo: { txId: string, outputIndex: number, value: number }, electrumx: ElectrumApiInterface) => {
+export const getInputUtxoFromTxid = async (utxo: UTXO, electrumx: ElectrumApiInterface) => {
   const txResult = await electrumx.getTx(utxo.txId);
 
   if (!txResult || !txResult.success) {
     throw `Transaction not found in getInputUtxoFromTxid ${utxo.txId}`;
   }
   const tx = txResult.tx;
-  utxo['nonWitnessUtxo'] = Buffer.from(tx, 'hex');
+  utxo.nonWitnessUtxo = Buffer.from(tx, 'hex');
 
   const reconstructedTx = bitcoin.Transaction.fromHex(tx.tx);
   if (reconstructedTx.getId() !== utxo.txId) {
@@ -58,7 +59,7 @@ export const getFundingUtxo = async (electrumxApi, address: string, amount: numb
   }
   console.log(`...`)
   console.log(`...`)
-  let fundingUtxo = await electrumxApi.waitUntilUTXO(address, amount, seconds ? 5 : seconds, false);
+  const fundingUtxo = await electrumxApi.waitUntilUTXO(address, amount, seconds ? 5 : seconds, false);
   console.log(`Detected Funding UTXO (${fundingUtxo.txid}:${fundingUtxo.vout}) with value ${fundingUtxo.value} for funding...`);
   return fundingUtxo
 }

--- a/lib/utils/select-funding-utxo.ts
+++ b/lib/utils/select-funding-utxo.ts
@@ -1,11 +1,9 @@
-import { ElectrumApiInterface } from "../api/electrum-api.interface";
+import { type ElectrumApiInterface } from "../api/electrum-api.interface";
 import { type UTXO } from "../types/UTXO.interface";
 import * as bitcoin from 'bitcoinjs-lib';
-import ECPairFactory from 'ecpair';
 import * as ecc from 'tiny-secp256k1';
 import * as qrcode from 'qrcode-terminal';
 bitcoin.initEccLib(ecc);
-const ECPair = ECPairFactory(ecc);
 
 export const getInputUtxoFromTxid = async (utxo: UTXO, electrumx: ElectrumApiInterface) => {
   const txResult = await electrumx.getTx(utxo.txId);


### PR DESCRIPTION
## Consideration

`getInputUtxoFromTxid` seems not in use, but a hack with bracket notation to avoid type warning could be a foot gun one day.

## Changes

- Enhance the type security to use `UXTO` from type definition. update UXTO type to have `nonWitnessUtxo?: Buffer;`
- Remove unused var and import
- Change `bitcoin-js` import to be module import