### PR TITLE
🐛 Fix wrong structure in returning results

### DIFF
--- a/lib/commands/broadcast-command.ts
+++ b/lib/commands/broadcast-command.ts
@@ -11,7 +11,7 @@ export class BroadcastCommand implements CommandInterface {
     const result = await this.electrumApi.broadcast(this.rawtx);
     return {
       success: true,
-      result,
+      data: result,
     };
   }
 }

--- a/lib/commands/get-container-item-validated-by-manifest-command.ts
+++ b/lib/commands/get-container-item-validated-by-manifest-command.ts
@@ -62,7 +62,7 @@ export class GetContainerItemValidatedByManifestCommand implements CommandInterf
     console.log('getItemCmdResponse', getItemCmdResponse)
     return {
       success: true,
-      result: getItemCmdResponse
+      data: getItemCmdResponse
     }
   }
 }

--- a/lib/commands/mint-interactive-ditem-command.ts
+++ b/lib/commands/mint-interactive-ditem-command.ts
@@ -91,8 +91,8 @@ export class MintInteractiveDitemCommand implements CommandInterface {
     });
     // Set to request a container
     atomicalBuilder.setRequestItem(this.requestDmitem, parentContainerId);
- 
-    await atomicalBuilder.setData({
+
+    atomicalBuilder.setData({
       [expectedData['args']['main']]: fileBuf
     });
 
@@ -120,7 +120,7 @@ export class MintInteractiveDitemCommand implements CommandInterface {
     });
     
      // The receiver output
-     atomicalBuilder.addOutput({
+    atomicalBuilder.addOutput({
       address: this.address,
       value: this.options.satsoutput as any || 1000
     });
@@ -128,7 +128,7 @@ export class MintInteractiveDitemCommand implements CommandInterface {
     
     return {
       success: true,
-      result
+      data: result,
     }
   }
 }


### PR DESCRIPTION
When commands are returned with results, some do not follow `{success: true, data: result}` structure, which produces `undefined` logging, e.g. `mint-item` and `broadcast`.

https://github.com/atomicals/atomicals-js/blob/80cd7b8ed14bcfa49b099c646fa8df7feb4a66d4/lib/cli.ts#L23-L28

![image](https://github.com/atomicals/atomicals-js/assets/15884415/e705b90d-a906-46f5-833d-c04770e81e72)
