### PR TITLE
🔥 Skip files starts with `.` rather than only `.`/`..`

### DIFF
--- a/lib/commands/create-dmint-command.ts
+++ b/lib/commands/create-dmint-command.ts
@@ -37,7 +37,8 @@ export class CreateDmintCommand implements CommandInterface {
     const leafItems: any = [];
     const jsonFiles = {};
     for (const file of files) {
-      if (file === '.' || file === '..' || file.startsWith('dmint')) {
+      if (file.startsWith('.') || file.startsWith('dmint')) {
+        console.log(`Skipping ${file}...`);
         continue;
       }
       counter++;

--- a/lib/commands/create-dmint-manifest-command.ts
+++ b/lib/commands/create-dmint-manifest-command.ts
@@ -29,7 +29,8 @@ export class CreateDmintItemManifestsCommand implements CommandInterface {
     const filemap = {};
     const leafItems: any = [];
     for (const file of files) {
-      if (file === '.' || file === '..') {
+      if (file.startsWith('.')) {
+        console.log(`Skipping ${file}...`);
         continue;
       }
       const basePath = basename(file);


### PR DESCRIPTION
Consider the folder contains `.DS_Store` on macOS. The change skips all hidden files (starts with `.`).