### PR TITLE
refactor: use `const` to define no changed variables

### DIFF
--- a/lib/utils/select-funding-utxo.ts
+++ b/lib/utils/select-funding-utxo.ts
@@ -26,9 +26,7 @@ export const getFundingSelectedUtxo = async (address: string, minFundingSatoshis
   // Query for a UTXO
   const listunspents = await electrumx.getUnspentAddress(address);
   const utxos = listunspents.utxos.filter((utxo) => {
-    if (utxo.value >= minFundingSatoshis) {
-      return utxo;
-    }
+    return utxo.value >= minFundingSatoshis
   });
   if (!utxos.length) {
     throw new Error(`Unable to select funding utxo, check at least 1 utxo contains ${minFundingSatoshis} satoshis`);

--- a/lib/utils/select-funding-utxo.ts
+++ b/lib/utils/select-funding-utxo.ts
@@ -24,8 +24,8 @@ export const getInputUtxoFromTxid = async (utxo: UTXO, electrumx: ElectrumApiInt
 
 export const getFundingSelectedUtxo = async (address: string, minFundingSatoshis: number, electrumx: ElectrumApiInterface): Promise<any> => {
   // Query for a UTXO
-  let listunspents = await electrumx.getUnspentAddress(address);
-  let utxos = listunspents.utxos.filter((utxo) => {
+  const listunspents = await electrumx.getUnspentAddress(address);
+  const utxos = listunspents.utxos.filter((utxo) => {
     if (utxo.value >= minFundingSatoshis) {
       return utxo;
     }
@@ -39,10 +39,10 @@ export const getFundingSelectedUtxo = async (address: string, minFundingSatoshis
 
 /**
      * Gets a funding UTXO and also displays qr code for quick deposit
-     * @param electrumxApi 
-     * @param address 
-     * @param amount 
-     * @returns 
+     * @param electrumxApi
+     * @param address
+     * @param amount
+     * @returns
      */
 export const getFundingUtxo = async (electrumxApi, address: string, amount: number, suppressDepositAddressInfo = false, seconds = 5) => {
   // We are expected to perform commit work, therefore we must fund with an existing UTXO first to generate the commit deposit address


### PR DESCRIPTION
refactor: use `const` to define no changed variables

simplify `filter` logic, clean code