### PR TITLE
Add optional CONCURRENCY parameter in .env for process control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,4 @@ WALLET_FILE=wallet.json
 # testnet or livenet or regtest
 NETWORK=livenet
 DISABLE_DONATE_QUOTE=false
+CONCURRENCY=4

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ ELECTRUMX_WSS=wss://electrumx.atomicals.xyz:50012
 
 // Optional (defaults to wallet.json)
 WALLET_PATH=path-to-wallet.json
+
+// The number of concurrent processes to be used. This should not exceed the number of CPU cores available. If not set, the default behavior is to use all available CPU cores minus one.
+CONCURRENCY=4
 ```
 
 _ELECTRUMX_WSS_: URL of the ElectrumX with Atomicals support. Note that only `wss` endpoints are accessible from web browsers.

--- a/lib/utils/atomical-operation-builder.ts
+++ b/lib/utils/atomical-operation-builder.ts
@@ -675,8 +675,16 @@ export class AtomicalOperationBuilder {
         // Close the electrum API connection
         this.options.electrumApi.close();
 
-        // Determine the number of concurrent workers to spawn
-        const concurrency = os.cpus().length - 1;
+        // Set the default concurrency level to the number of CPU cores minus 1
+        const defaultConcurrency = os.cpus().length - 1;
+        // Read the concurrency level from .env file
+        const envConcurrency = process.env.CONCURRENCY ? parseInt(process.env.CONCURRENCY, 10) : NaN;
+        // Use envConcurrency if it is a positive number and less than or equal to defaultConcurrency; otherwise, use defaultConcurrency
+        const concurrency = (!isNaN(envConcurrency) && envConcurrency > 0 && envConcurrency <= defaultConcurrency)
+            ? envConcurrency
+            : defaultConcurrency;
+        // Logging the set concurrency level to the console
+        console.log(`Concurrency set to: ${concurrency}`);
         const workerOptions = this.options;
         const workerBitworkInfoCommit = this.bitworkInfoCommit;
 


### PR DESCRIPTION
This commit introduces the CONCURRENCY parameter in the .env file, allowing users to specify the number of concurrent processes. This enhancement provides better control over resource usage, especially on systems with multiple CPU cores. The functionality defaults to using all available CPU cores minus one if CONCURRENCY is not explicitly set. This update includes modifications in the code to handle this new configuration and updates to the README for clear guidance.