### PR TITLE
Update the isOpenFlag property

### DIFF
--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -20,7 +20,7 @@ export class ElectrumApi implements ElectrumApiInterface {
         return new ElectrumApi(url, usePost);
     }
 
-    public open(): Promise<any> {
+    public async open(): Promise<any> {
         return new Promise((resolve) => {
             if (this.isOpenFlag) {
                 resolve(true);
@@ -35,7 +35,7 @@ export class ElectrumApi implements ElectrumApiInterface {
         return this.isOpenFlag;
     }
 
-    public close(): Promise<any> {
+    public async close(): Promise<any> {
         this.isOpenFlag = false;
         return Promise.resolve(true);
     }

--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -13,7 +13,7 @@ export class ElectrumApi implements ElectrumApiInterface {
     }
 
     public async resetConnection() {
-
+        this.isOpenFlag = false;
     }
 
     static createClient(url: string, usePost = true) {
@@ -26,6 +26,7 @@ export class ElectrumApi implements ElectrumApiInterface {
                 resolve(true);
                 return;
             }
+            this.isOpenFlag = true;
             resolve(true);
         });
     }
@@ -35,6 +36,7 @@ export class ElectrumApi implements ElectrumApiInterface {
     }
 
     public close(): Promise<any> {
+        this.isOpenFlag = false;
         return Promise.resolve(true);
     }
 


### PR DESCRIPTION
Hey team,

 I noticed that we're not updating the isOpenFlag property in the open() / close() method. What this means is that even if you call open(), the isOpen() method will still think we're not connected and return false.

Fix:
1. Updating the isOpenFlag property in the open() / close() / resetConnection() method
2. Adding async keyword
