### PR TITLE
Remove unnecessary utf8 encoding

### DIFF
--- a/lib/utils/miner-worker.ts
+++ b/lib/utils/miner-worker.ts
@@ -314,13 +314,9 @@ export const appendMintUpdateRevealScript = (
     payload: AtomicalsPayload,
     log: boolean = true
 ) => {
-    let ops = `${Buffer.from(keypair.childNodeXOnlyPubkey, "utf8").toString(
-        "hex"
-    )} OP_CHECKSIG OP_0 OP_IF `;
-    ops += `${Buffer.from(ATOMICALS_PROTOCOL_ENVELOPE_ID, "utf8").toString(
-        "hex"
-    )}`;
-    ops += ` ${Buffer.from(opType, "utf8").toString("hex")}`;
+    let ops = `${Buffer.from(keypair.childNodeXOnlyPubkey).toString("hex")} OP_CHECKSIG OP_0 OP_IF `;
+    ops += `${Buffer.from(ATOMICALS_PROTOCOL_ENVELOPE_ID).toString("hex")}`;
+    ops += ` ${Buffer.from(opType).toString("hex")}`;
     const chunks = chunkBuffer(payload.cbor(), 520);
     for (let chunk of chunks) {
         ops += ` ${chunk.toString("hex")}`;


### PR DESCRIPTION
Hey team,

Do we need to interpret the binary data as UTF-8 encoded text?  Shall we just treat the binary data as raw bytes and convert each byte to its hex representation? This way, the integrity of the original binary data is maintained, and the final hex string is an accurate representation of the binary data. 