### PR TITLE
chore: CONCURRENCY can be gt CPU cores

### DIFF
--- a/lib/utils/atomical-operation-builder.ts
+++ b/lib/utils/atomical-operation-builder.ts
@@ -679,14 +679,11 @@ export class AtomicalOperationBuilder {
         // Read the concurrency level from .env file
         const envConcurrency = process.env.CONCURRENCY
             ? parseInt(process.env.CONCURRENCY, 10)
-            : NaN;
-        // Use envConcurrency if it is a positive number and less than or equal to defaultConcurrency; otherwise, use defaultConcurrency
-        const concurrency =
-            !isNaN(envConcurrency) &&
-            envConcurrency > 0 &&
-            envConcurrency <= defaultConcurrency
-                ? envConcurrency
-                : defaultConcurrency;
+            : -1;
+        // Use envConcurrency if it is a positive number; otherwise, use defaultConcurrency
+        const concurrency = envConcurrency > 0
+            ? envConcurrency
+            : defaultConcurrency;
         // Logging the set concurrency level to the console
         console.log(`Concurrency set to: ${concurrency}`);
         const workerOptions = this.options;


### PR DESCRIPTION
When mint `quark`, I found that with default concurrency (cpus-1):

- `CPU Usage` is about 60-70%.
- `LOAD` is half of the cpu cores.

Aasked some of my friends, they met same problem.

Maybe we can cancel the max limit of `CONCURRENCY`. Let users choose by themselves.