### PR TITLE
fix: allow initialowner to be set directly to wallet address

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1571,7 +1571,7 @@ program.command('mint-dft')
       const config: ConfigurationInterface = validateCliInputs();
       ticker = ticker.toLowerCase();
       const atomicals = new Atomicals(ElectrumApi.createClient(process.env.ELECTRUMX_PROXY_BASE_URL || ''));
-      let walletRecord = resolveWalletAliasNew(walletInfo, options.initialowner, walletInfo.primary);
+      let walletRecord = resolveAddress(walletInfo, options.initialowner, walletInfo.primary);
       let fundingRecord = resolveWalletAliasNew(walletInfo, options.funding, walletInfo.funding);
       const result: any = await atomicals.mintDftInteractive({
         rbf: options.rbf,


### PR DESCRIPTION
Allow `--initialowner` to be directly set to wallet address in `mint-dft` command. Like:
```sh
yarn cli mint-dft quark --initialowner bc1p...
```