### PR TITLE
Print reveal raw tx after mining succeed

### DIFF
--- a/lib/utils/atomical-operation-builder.ts
+++ b/lib/utils/atomical-operation-builder.ts
@@ -995,6 +995,7 @@ export class AtomicalOperationBuilder {
             }
 
             const revealTx = psbt.extractTransaction();
+            console.log("\nPrint raw tax in case of broadcast failed", revealTx.toHex();
             const checkTxid = revealTx.getId();
             logMiningProgressToConsole(
                 performBitworkForRevealTx,


### PR DESCRIPTION
Sometimes reveal transaction couldn't broadcast because of rpc error, user can not broadcast manually.