### PR TITLE
Remove extra property

### DIFF
--- a/lib/utils/select-funding-utxo.ts
+++ b/lib/utils/select-funding-utxo.ts
@@ -8,13 +8,13 @@ bitcoin.initEccLib(ecc);
 export const getInputUtxoFromTxid = async (utxo: UTXO, electrumx: ElectrumApiInterface) => {
   const txResult = await electrumx.getTx(utxo.txId);
 
-  if (!txResult || !txResult.success) {
+  if (!txResult || !txResult.success || !txResult.tx) {
     throw `Transaction not found in getInputUtxoFromTxid ${utxo.txId}`;
   }
   const tx = txResult.tx;
   utxo.nonWitnessUtxo = Buffer.from(tx, 'hex');
 
-  const reconstructedTx = bitcoin.Transaction.fromHex(tx.tx);
+  const reconstructedTx = bitcoin.Transaction.fromHex(tx);
   if (reconstructedTx.getId() !== utxo.txId) {
     throw "getInputUtxoFromTxid txid mismatch error";
   }


### PR DESCRIPTION
since we have already retrieved txResult.tx, it seems unnecessary to use tx.tx again. @atomicals  Could you please confirm the structure of the txResult object? As txResult is of type any, its properties are not immediately clear.