### PR TITLE
feat: support multiple electrum endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 # Bitcoin (Testnet):
 # ELECTRUMX_PROXY_BASE_URL=https://eptestnet.atomicals.xyz/proxy
 
-ELECTRUMX_PROXY_BASE_URL=https://ep.atomicals.xyz/proxy
+ELECTRUMX_PROXY_BASE_URL=https://ep.atomicals.xyz/proxy,https://ep.atomicalmarket.com/proxy,https://ep.nextdao.xyz/proxy,https://ep.consync.xyz/proxy
 WALLET_PATH=./wallets
 WALLET_FILE=wallet.json
 # testnet or livenet or regtest

--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -59,7 +59,7 @@ export class ElectrumApi implements ElectrumApiInterface {
                 return response.data.response;
             } catch (error) {
                 err = error;
-                console.log("use endpoint", baseUrl, "got err", err.message);
+                console.log("use endpoint", baseUrl, "got err", err);
             }
         }
         throw err;


### PR DESCRIPTION
This pr added support for setting multiple endpoints with comma `,` in `.env` file.

`ELECTRUMX_PROXY_BASE_URL=https://ep.atomicalmarket.com/proxy,https://ep.atomicals.xyz/proxy`

And after failing to call one of the endpoints, will retry for another one. This is useful when one endpoint always returns `500` or `503` with a high server load.

Also, we can implement a client-side load balancer in the future