### PR TITLE
exit with a non-0 exit code when the result is failure

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -56,6 +56,7 @@ function printFailure(data: any) {
 function handleResultLogging(result: any, showDonation?: boolean) {
   if (!result || !result.success || !result.data) {
     printFailure(result);
+    process.exit(1);
   } else {
     printSuccess(result.data, showDonation);
   }


### PR DESCRIPTION
always exit with exit code 0 is unfriendly to other external programs.

we need to exit with a non-0 exit code when the result is failure.
