### PR TITLE
support mint dft atomi & btc & atomicals

### DIFF
--- a/lib/commands/mint-interactive-dft-command.ts
+++ b/lib/commands/mint-interactive-dft-command.ts
@@ -104,7 +104,7 @@ export class MintInteractiveDftCommand implements CommandInterface {
       atomicalBuilder.setContainerMembership(this.options.container);
 
     // Attach any requested bitwork OR automatically request bitwork if the parent decentralized ft requires it
-    const mint_bitworkc = atomicalDecorated['$mint_bitworkc'] || this.options.bitworkc
+    const mint_bitworkc = atomicalDecorated['$mint_bitworkc'] || atomicalDecorated['$bitwork']?.bitworkc || this.options.bitworkc
     if (mint_bitworkc) {
       atomicalBuilder.setBitworkCommit(mint_bitworkc);
     }


### PR DESCRIPTION
The definitions of these DFT bitworks are as follows:
```
'$bitwork': { bitworkc: '2324', bitworkr: null }
```
It is not $mint_bitworkc, therefore the mint command cannot execute normally.