### PR TITLE
refactor: redirect log output to terminal and file simultaneously

### DIFF
--- a/.env
+++ b/.env
@@ -16,3 +16,7 @@ WALLET_FILE=wallet.json
 # testnet or livenet or regtest
 NETWORK=livenet
 DISABLE_DONATE_QUOTE=false
+# set whether to write the output to log file
+LOG_TO_FILE=false
+# set the log file path, only valid when LOG_TO_FILE=true, default is log.txt
+LOG_FILE=log.txt

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import { APIInterface, BaseRequestOptions } from "./interfaces/api.interface";
 const bitcoin = require('bitcoinjs-lib');
 import * as ecc from 'tiny-secp256k1';
+import * as dotenv from 'dotenv'
 bitcoin.initEccLib(ecc);
 import * as cbor from 'borc';
 export { ElectrumApiMock } from "./api/electrum-api-mock";
@@ -84,6 +85,7 @@ export { buildAtomicalsFileMapFromRawTx, hexifyObjectWithUtf8, isValidRealmName,
 export { createMnemonicPhrase } from "./utils/create-mnemonic-phrase";
 export { detectAddressTypeToScripthash, detectScriptToAddressType } from "./utils/address-helpers";
 
+dotenv.config();
 export { bitcoin };
 export class Atomicals implements APIInterface {
   constructor(private electrumApi: ElectrumApiInterface) {
@@ -1361,6 +1363,22 @@ try {
     window['atomicals'] = {
       instance: instance
     };
+  } else {
+    if (process.env.LOG_TO_FILE && process.env.LOG_TO_FILE === 'true') {
+      const fs = require('fs');
+      const path = process.env.LOG_FILE || 'log.txt';
+      const logStream = fs.createWriteStream(path, { flags: 'a' });
+
+      const originalLog = console.log;
+
+      console.log = function(data) {
+        originalLog(data);
+        if (typeof data === 'object') {
+          data = JSON.stringify(data);
+        }
+        logStream.write(data + '\n');
+      };
+    }
   }
 }
 catch (ex) {


### PR DESCRIPTION
Since `console.log` will print the error message directly to the terminal, and `axios errors` is such messy that will soon exceed the terminal's max buffer size, this pr added a simple way to write the output to log file `log.txt`.

This is also helpful for us to check the log and do some remedies when we hang or fail somewhere.😀