### PR TITLE
[PoW Lab] Enhance hash rate 5x by reducing the use of  `await sleep(0)`.

### DIFF
--- a/lib/utils/miner-worker.ts
+++ b/lib/utils/miner-worker.ts
@@ -128,8 +128,6 @@ if (parentPort) {
 
         // Start mining loop, terminates when a valid proof of work is found or stopped manually
         do {
-            // Introduce a minor delay to avoid overloading the CPU
-            await sleep(0);
 
             // This worker has tried all assigned sequence range but it did not find solution.
             if (sequence > seqEnd) {
@@ -211,6 +209,7 @@ if (parentPort) {
                 );
                 lastTime = Date.now();
                 lastGenerated = generated;
+                await sleep(0);
             }
         } while (workerPerformBitworkForCommitTx);
 

--- a/lib/utils/miner-worker.ts
+++ b/lib/utils/miner-worker.ts
@@ -122,6 +122,10 @@ if (parentPort) {
         };
         let finalCopyData, finalPrelimTx, finalSequence;
 
+        let lastGenerated = 0;
+        let generated = 0;
+        let lastTime = Date.now();
+
         // Start mining loop, terminates when a valid proof of work is found or stopped manually
         do {
             // Introduce a minor delay to avoid overloading the CPU
@@ -196,6 +200,18 @@ if (parentPort) {
             }
 
             sequence++;
+            generated++;
+
+            if (generated % 10000 === 0) {
+                const hashRate = ((generated - lastGenerated) / (Date.now() - lastTime)) * 1000;
+                console.log(
+                    'Hash rate:',
+                    hashRate.toFixed(2),
+                    'Op/s ',
+                );
+                lastTime = Date.now();
+                lastGenerated = generated;
+            }
         } while (workerPerformBitworkForCommitTx);
 
         if (finalSequence && finalSequence != -1) {


### PR DESCRIPTION
# What

We ([PoW Lab](https://twitter.com/pow_lab)) are dedicated to promoting Proof of Work (PoW) consensus and firmly believe that PoW consensus is the fairest game in the blockchain space. We appreciate the Atomicals project but have identified several issues in this project (atomicals-js) that affect mining hash rates. Therefore, we have decided to optimize the open-source code through our efforts to ensure that everyone can achieve high hash rates. This is the first in our series of PRs.

# How

Firstly, we added a [commit](https://github.com/atomicals/atomicals-js/commit/4996dca39334874c45670fa8f545a39bd0c5d2b5) that outputs hash rates every 10,000 hashes. The purpose is to quantify hash rates more clearly for subsequent optimizations.

Then, in this [commit](https://github.com/atomicals/atomicals-js/commit/34a249117e891351839ac091d9aecc238beb3061), we modified the position of `await sleep(0)`, significantly reducing its number of calls and thereby increasing the hash rate by approximately 5 times.

# Why

The essence of `await sleep(0)` is calling `setTimeout(fn, 0)`. As [this document](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#nested_timeouts) shows, even with 0 milliseconds as a parameter, setTimeout may still be executed with a delay of 4 milliseconds. This prevents PoW mining code from running at 100% capacity, significantly reducing mining hash rates. According to our practical tests, using a single thread on an M1 Max MacBook Pro (`CONCURRENCY=1`) resulted in over a 5x improvement:

Before:

![Before](https://github.com/atomicals/atomicals-js/assets/157621944/7805fb5d-8416-4781-a23f-25c73fa8a721)

After:

![After](https://github.com/atomicals/atomicals-js/assets/157621944/0248b17e-5318-4b33-941e-0edf2f78875f)

---

# 是什么

我们（[PoW Lab](https://twitter.com/pow_lab)）致力于推动工作证明（PoW）共识，并坚信PoW共识是区块链领域中最公平的游戏。我们赞赏Atomicals项目，但在该项目（atomicals-js）中发现了一些影响挖矿算力的问题。因此，我们决定通过我们的努力优化开源代码，以确保每个人都能实现高算力。这是我们系列PR中的第一个。

# 怎么做

首先，我们添加了一个[提交](https://github.com/atomicals/atomicals-js/commit/4996dca39334874c45670fa8f545a39bd0c5d2b5)，每10,000个哈希输出一次算力。目的是为了更清晰地量化后续的优化算力。

然后，在这个[提交](https://github.com/atomicals/atomicals-js/commit/34a249117e891351839ac091d9aecc238beb3061)中，我们修改了`await sleep(0)`的位置，显著减少了它的调用次数，从而将算力提高了约5倍。

# 为什么

`await sleep(0)`的本质是调用`setTimeout(fn, 0)`。正如[这份文档](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#nested_timeouts)所示，即使参数为0毫秒，setTimeout仍可能延迟4毫秒执行。这阻止了PoW挖矿代码以100%的容量运行，从而显著降低了挖矿算力。根据我们的实际测试，在M1 Max MacBook Pro上使用单线程（`CONCURRENCY=1`）实现了5倍以上的改善：

之前：

![之前](https://github.com/atomicals/atomicals-js/assets/157621944/7805fb5d-8416-4781-a23f-25c73fa8a721)

之后：

![之后](https://github.com/atomicals/atomicals-js/assets/157621944/0248b17e-5318-4b33-941e-0edf2f78875f)
