### PR TITLE
🚸 Log container error status while validating

### DIFF
--- a/lib/commands/get-container-item-validated-by-manifest-command.ts
+++ b/lib/commands/get-container-item-validated-by-manifest-command.ts
@@ -24,7 +24,6 @@ export class GetContainerItemValidatedByManifestCommand implements CommandInterf
     private requestDmitem: string,
     private manifestJsonFile: string
   ) {
-  
     this.container = this.container.startsWith('#') ? this.container.substring(1) : this.container;
   }
   async run(): Promise<any> {
@@ -38,6 +37,10 @@ export class GetContainerItemValidatedByManifestCommand implements CommandInterf
       }
     }
     const parentContainerId = getResponse.data.result.atomical_id;
+    const errors: string[] = getResponse.data.result.$container_dmint_status?.errors;
+    if (errors !== undefined && errors.length > 0) {
+      console.error('Container status errors: ', errors)
+    }
     // Step 0. Get the details from the manifest
     const jsonFile: any = await jsonFileReader(this.manifestJsonFile);
     const expectedData = jsonFile['data'];
@@ -59,7 +62,6 @@ export class GetContainerItemValidatedByManifestCommand implements CommandInterf
     }
     const getItemCmd = new GetContainerItemValidatedCommand(this.electrumApi, this.container, this.requestDmitem, bitworkc, bitworkr, main, mainHash, proof, true);
     const getItemCmdResponse = await getItemCmd.run();
-    console.log('getItemCmdResponse', getItemCmdResponse)
     return {
       success: true,
       data: getItemCmdResponse


### PR DESCRIPTION
Displays errors which would help to determine the container status before it hits validation failure.