### PR TITLE
[PoW Lab] Fix an issue that bitworkc lengths greater than 8 bits may never being mined

### DIFF
--- a/lib/utils/miner-worker.ts
+++ b/lib/utils/miner-worker.ts
@@ -120,7 +120,7 @@ if (parentPort) {
             address: updatedBaseCommit.scriptP2TR.address,
             value: getOutputValueForCommit(fees),
         };
-        let finalCopyData, finalPrelimTx, finalSequence;
+        let finalCopyData, finalPrelimTx;
 
         let lastGenerated = 0;
         let generated = 0;
@@ -128,10 +128,24 @@ if (parentPort) {
 
         // Start mining loop, terminates when a valid proof of work is found or stopped manually
         do {
-
-            // This worker has tried all assigned sequence range but it did not find solution.
+            // If the sequence has exceeded the max sequence allowed, generate a newtime and reset the sequence until we find one.
             if (sequence > seqEnd) {
-                finalSequence = -1;
+                copiedData["args"]["time"] = Math.floor(Date.now() / 1000);
+
+                atomPayload = new AtomicalsPayload(copiedData);
+                const newBaseCommit: { scriptP2TR; hashLockP2TR; hashscript } =
+                    workerPrepareCommitRevealConfig(
+                        workerOptions.opType,
+                        fundingKeypair,
+                        atomPayload
+                    );
+                updatedBaseCommit = newBaseCommit;
+                fixedOutput = {
+                    address: updatedBaseCommit.scriptP2TR.address,
+                    value: getOutputValueForCommit(fees),
+                };
+
+                sequence = seqStart;
             }
             if (sequence % 10000 == 0) {
                 console.log(
@@ -192,7 +206,6 @@ if (parentPort) {
 
                 finalCopyData = copiedData;
                 finalPrelimTx = prelimTx;
-                finalSequence = sequence;
                 workerPerformBitworkForCommitTx = false;
                 break;
             }
@@ -213,21 +226,19 @@ if (parentPort) {
             }
         } while (workerPerformBitworkForCommitTx);
 
-        if (finalSequence && finalSequence != -1) {
-            // send a result or message back to the main thread
-            console.log(
-                "Got one finalCopyData: " + JSON.stringify(finalCopyData)
-            );
-            console.log(
-                "Got one finalPrelimTx: " + finalPrelimTx.toString()
-            );
-            console.log("Got one finalSequence: " + JSON.stringify(sequence));
+        // send a result or message back to the main thread
+        console.log(
+            "Got one finalCopyData: " + JSON.stringify(finalCopyData)
+        );
+        console.log(
+            "Got one finalPrelimTx: " + finalPrelimTx.toString()
+        );
+        console.log("Got one finalSequence: " + JSON.stringify(sequence));
 
-            parentPort!.postMessage({
-                finalCopyData,
-                finalSequence: sequence,
-            });
-        }
+        parentPort!.postMessage({
+            finalCopyData,
+            finalSequence: sequence,
+        });
     });
 }
 


### PR DESCRIPTION
# What

We ([PoW Lab](https://twitter.com/pow_lab)) are dedicated to promoting Proof of Work (PoW) consensus and firmly believe that PoW consensus is the fairest game in the blockchain space.

During our process of optimizing the hash rate for atomicals-js, we discovered a serious issue that could potentially result in bitworkc lengths greater than 8 bits never being mined.

# Why

In https://github.com/atomicals/atomicals-js/pull/156, each worker is responsible for computing a portion of the range from 0 to MAX_SEQUENCE. For instance, if there are N workers, then they each handle ranges like 0 to 1/N*MAX_SEQUENCE, 1/N*MAX_SEQUENCE to 2/N*MAX_SEQUENCE, and so on. Due to a bug in [this code](https://github.com/NeutronProtocol/atomicals-js/blob/644b8de7d20c630176272334c27810e4d093fb3a/lib/utils/miner-worker.ts#L132-L135), workers continue to run even after the `sequence` exceeds `seqEnd`, until they find a transaction that meets the requirements of `bitworkc`.

On one hand, workers may compute tasks that do not belong to them, resulting in wasted computational power. On the other hand, for cases where the bitworkc length is greater than 8, even enumerating sequence from 0 to MAX_SEQUENCE does not guarantee the mining of a token, potentially leading to perpetual unsuccessful mining attempts.

To reproduce this issue, you can checkout [this commit](https://github.com/pow-lab/atomicals-js/commit/af27104469829ac726eb4422d21d8d326c8f6a0e) and run `yarn build && CONCURRENCY=1 yarn cli mint-dft photon --satsbyte=40`.

<img width="633" alt="image" src="https://github.com/atomicals/atomicals-js/assets/157621944/bddfcb6c-a3e1-44ff-a572-a867c14f85f8">

As you can see above, although we mocked the `MAX_SEQUENCE` to `0x00000000FF`, the final sequence is 11749 that exceeds the limit.

# How

To fix this bug, we need to revert some of the code changes made in https://github.com/atomicals/atomicals-js/pull/156, specifically the logic related to `sequence` greater than `seqEnd`.

When `sequence` exceed `seqEnd`, we need to adjust the `time` field in `AtomicalsPayload` and reset `sequence` to `seqStart` for a new round of minting.

---

# 是什么

我们（[PoW Lab](https://twitter.com/pow_lab)）致力于推动工作量证明（PoW）共识，并坚信PoW共识是区块链领域中最公平的游戏。

在我们优化atomicals-js的哈希率过程中，我们发现了一个严重的问题，可能导致bitworkc长度大于8位的bitworkc永远无法被挖掘。

# 为什么

在 https://github.com/atomicals/atomicals-js/pull/156 中，每个worker负责计算从0到MAX_SEQUENCE范围的一部分。例如，如果有N个worker，那么每个worker处理的范围是0到1/N*MAX_SEQUENCE，1/N*MAX_SEQUENCE到2/N*MAX_SEQUENCE，依此类推。由于[此代码](https://github.com/NeutronProtocol/atomicals-js/blob/644b8de7d20c630176272334c27810e4d093fb3a/lib/utils/miner-worker.ts#L132-L135)中存在一个错误，在`sequence`超过`seqEnd`之后，worker会继续运行直到找到满足`bitworkc`要求的交易。

一方面，工作者可能计算不属于它们的任务，导致算力浪费；另一方面，对于bitworkc长度大于8的情况，即使枚举从0到MAX_SEQUENCE的所有序列也不能保证挖掘到token，可能导致永远无法挖掘成功。

要重现此问题，您可以检出[此提交](https://github.com/pow-lab/atomicals-js/commit/af27104469829ac726eb4422d21d8d326c8f6a0e)，然后运行`yarn build && CONCURRENCY=1 yarn cli mint-dft photon --satsbyte=40`。

<img width="633" alt="image" src="https://github.com/atomicals/atomicals-js/assets/157621944/bddfcb6c-a3e1-44ff-a572-a867c14f85f8">

如上所示，尽管我们将`MAX_SEQUENCE`设置为`0x00000000FF`，但最终sequence是11749，超出了限制。

# 怎么办

要修复此错误，我们需要回滚 https://github.com/atomicals/atomicals-js/pull/156 中所做的部分代码更改，具体是 `sequences` 大于`seqEnd`的相关的逻辑。

当`sequences`超过`seqEnd`时，我们需要调整`AtomicalsPayload`中的`time`字段，并重置`sequences`为`seqStart`，以开启新的一轮挖掘。

cc @atomicals @NeutronProtocol