### PR TITLE
fix yarn cli get command caseinsensitive

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1266,10 +1266,11 @@ program.command('get')
   .action(async (atomicalAliasOrId, options) => {
     try {
       await validateWalletStorage();
+      const atomicalAliasOrIdLC = atomicalAliasOrId.toLowerCase()
       const config: ConfigurationInterface = validateCliInputs();
       const atomicals = new Atomicals(ElectrumApi.createClient(process.env.ELECTRUMX_PROXY_BASE_URL || ''));
       const verbose = options.verbose ? true : false;
-      const result = await atomicals.resolveAtomical(atomicalAliasOrId, AtomicalsGetFetchType.GET, undefined, verbose);
+      const result = await atomicals.resolveAtomical(atomicalAliasOrIdLC, AtomicalsGetFetchType.GET, undefined, verbose);
       handleResultLogging(result, true);
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
During deployment, uppercase letters are supported, but when using the 'get' command, it cannot be found with uppercase letters; you need to use lowercase letters.






