### PR TITLE
add custom color command

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1258,6 +1258,30 @@ program.command('split')
   });
 */
 
+program.command('custom-color')
+  .description('custom color operation to separate the FT Atomicals at a single UTXOs.')
+  .argument('<locationId>', 'string')
+  .option('--rbf', 'Whether to enable RBF for transactions.')
+  .option('--funding <string>', 'Use wallet alias wif key to be used for funding')
+  .option('--owner <string>', 'Use wallet alias WIF key to move the Atomical')
+  .option('--satsbyte <number>', 'Satoshis per byte in fees', '15')
+  .action(async (locationId, options) => {
+    try {
+      const walletInfo = await validateWalletStorage();
+      const config: ConfigurationInterface = validateCliInputs();
+      const atomicals = new Atomicals(ElectrumApi.createClient(process.env.ELECTRUMX_PROXY_BASE_URL || ''));
+      let fundingWalletRecord = resolveWalletAliasNew(walletInfo, options.funding, walletInfo.funding);
+      let ownerWalletRecord = resolveWalletAliasNew(walletInfo, options.owner, walletInfo.primary);
+      const result: any = await atomicals.customColorItneractive({
+        rbf: options.rbf,
+        satsbyte: parseInt(options.satsbyte),
+      }, locationId, fundingWalletRecord, ownerWalletRecord);
+      handleResultLogging(result);
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
 program.command('get')
   .description('Get the status of an Atomical')
   .argument('<atomicalAliasOrId>', 'string')

--- a/lib/commands/command-helpers.ts
+++ b/lib/commands/command-helpers.ts
@@ -76,7 +76,7 @@ export const calculateUtxoFundsRequired = (numberOfInputs, numberOfOutputs, sats
 
 
 
-export const appendMintUpdateRevealScript2 = (opType: 'nft' | 'ft' | 'dft' | 'dmt' | 'sl' | 'x' | 'y' | 'mod' | 'evt', keypair: KeyPairInfo, files: AtomicalFileData[], log: boolean = true) => {
+export const appendMintUpdateRevealScript2 = (opType: 'nft' | 'ft' | 'dft' | 'dmt' | 'sl' | 'x' | 'y' | 'z' | 'mod' | 'evt', keypair: KeyPairInfo, files: AtomicalFileData[], log: boolean = true) => {
     let ops = `${keypair.childNodeXOnlyPubkey.toString('hex')} OP_CHECKSIG OP_0 OP_IF `;
     ops += `${Buffer.from(ATOMICALS_PROTOCOL_ENVELOPE_ID, 'utf8').toString('hex')}`;
     ops += ` ${Buffer.from(opType, 'utf8').toString('hex')}`;
@@ -115,7 +115,7 @@ export const appendMintUpdateRevealScript2 = (opType: 'nft' | 'ft' | 'dft' | 'dm
     return ops;
 };
 
-export const prepareCommitRevealConfig2 = (opType: 'nft' | 'ft' | 'dft' | 'dmt' | 'sl' | 'x' | 'y' | 'mod' | 'evt', keypair: KeyPairInfo, filesData: AtomicalFileData[], log = true) => {
+export const prepareCommitRevealConfig2 = (opType: 'nft' | 'ft' | 'dft' | 'dmt' | 'sl' | 'x' | 'y' | 'z' | 'mod' | 'evt', keypair: KeyPairInfo, filesData: AtomicalFileData[], log = true) => {
     const revealScript = appendMintUpdateRevealScript2(opType, keypair, filesData, log);
     const hashscript = script.fromASM(revealScript);
     const scriptTree = {
@@ -144,7 +144,7 @@ export const prepareCommitRevealConfig2 = (opType: 'nft' | 'ft' | 'dft' | 'dmt' 
     }
 }
 
-export const prepareCommitRevealConfig = (opType: 'nft' | 'ft' | 'dft' | 'dmt' | 'sl' | 'x' | 'y' | 'mod' | 'evt' | 'dat', keypair: KeyPairInfo, atomicalsPayload: AtomicalsPayload, log = true) => {
+export const prepareCommitRevealConfig = (opType: 'nft' | 'ft' | 'dft' | 'dmt' | 'sl' | 'x' | 'y' | 'z' | 'mod' | 'evt' | 'dat', keypair: KeyPairInfo, atomicalsPayload: AtomicalsPayload, log = true) => {
     const revealScript = appendMintUpdateRevealScript(opType, keypair, atomicalsPayload, log);
     const hashscript = script.fromASM(revealScript);
     const scriptTree = {
@@ -524,7 +524,7 @@ export class AtomicalsPayload {
     }
 }
 
-export const appendMintUpdateRevealScript = (opType: 'nft' | 'ft' | 'dft' | 'dmt' | 'sl' | 'x' | 'y' | 'mod' | 'evt' | 'dat', keypair: KeyPairInfo, payload: AtomicalsPayload, log: boolean = true) => {
+export const appendMintUpdateRevealScript = (opType: 'nft' | 'ft' | 'dft' | 'dmt' | 'sl' | 'x' | 'y' | 'z' | 'mod' | 'evt' | 'dat', keypair: KeyPairInfo, payload: AtomicalsPayload, log: boolean = true) => {
     let ops = `${keypair.childNodeXOnlyPubkey.toString('hex')} OP_CHECKSIG OP_0 OP_IF `;
     ops += `${Buffer.from(ATOMICALS_PROTOCOL_ENVELOPE_ID, 'utf8').toString('hex')}`;
     ops += ` ${Buffer.from(opType, 'utf8').toString('hex')}`;

--- a/lib/commands/custom-color-interactive-command.ts
+++ b/lib/commands/custom-color-interactive-command.ts
@@ -1,0 +1,170 @@
+import { ElectrumApiInterface } from "../api/electrum-api.interface";
+import { CommandInterface } from "./command.interface";
+import * as ecc from 'tiny-secp256k1';
+import { TinySecp256k1Interface } from 'ecpair';
+import * as readline from 'readline';
+const bitcoin = require('bitcoinjs-lib');
+bitcoin.initEccLib(ecc);
+import {
+  initEccLib,
+} from "bitcoinjs-lib";
+import { logBanner } from "./command-helpers";
+import { AtomicalOperationBuilder } from "../utils/atomical-operation-builder";
+import { BaseRequestOptions } from "../interfaces/api.interface";
+import { IWalletRecord } from "../utils/validate-wallet-storage";
+import { GetAtomicalsAtLocationCommand } from "./get-atomicals-at-location-command";
+import { GetUtxoPartialFromLocation } from "../utils/address-helpers";
+import { IInputUtxoPartial } from "../types/UTXO.interface";
+import { hasAtomicalType, isAtomicalId } from "../utils/atomical-format-helpers";
+
+const tinysecp: TinySecp256k1Interface = require('tiny-secp256k1');
+initEccLib(tinysecp as any);
+
+
+export class customColorInteractiveCommand implements CommandInterface {
+  constructor(
+    private electrumApi: ElectrumApiInterface,
+    private options: BaseRequestOptions,
+    private locationId: string,
+    private owner: IWalletRecord,
+    private funding: IWalletRecord,
+  ) {
+  }
+  async run(): Promise<any> {
+    logBanner(`Custom color FTs Interactive`);
+    const command: CommandInterface = new GetAtomicalsAtLocationCommand(this.electrumApi, this.locationId);
+    const response: any = await command.run();
+    if (!response || !response.success) {
+      throw new Error(response);
+    }
+    const atomicals = response.data.atomicals;
+
+    const hasNfts = hasAtomicalType('NFT', atomicals);
+    if (hasNfts) {
+      console.log('Found at least one NFT at the same location. The first output will contain the NFTs, and the second output, etc will contain the FTs split out. After you may use the splat command to separate multiple NFTs if they exist at the same location.')
+    }
+
+    const inputUtxoPartial: IInputUtxoPartial | any = GetUtxoPartialFromLocation(this.owner.address, response.data.location_info);
+    const atomicalBuilder = new AtomicalOperationBuilder({
+      electrumApi: this.electrumApi,
+      rbf: this.options.rbf,
+      satsbyte: this.options.satsbyte,
+      address: this.owner.address,
+      disableMiningChalk: this.options.disableMiningChalk,
+      opType: 'z',
+      skipOptions: {
+      },
+      meta: this.options.meta,
+      ctx: this.options.ctx,
+      init: this.options.init,
+    });
+
+    // Add the owner of the atomicals at the location
+    atomicalBuilder.addInputUtxo(inputUtxoPartial, this.owner.WIF)
+    const atomicalsToColored: any = {}
+    let index = 0;
+    for (const atomical of atomicals) {
+      if (!atomical.atomical_id) {
+        throw new Error('Critical error atomical_id not set for FT');
+      }
+      if (!isAtomicalId(atomical.atomical_id)) {
+        throw new Error('Critical error atomical_id is not valid for FT');
+      }
+      
+      const outputs: {} = await this.promptCustomColored(index, atomical.value);
+
+      // Make sure to make N outputs, for each atomical NFT
+      atomicalsToColored[atomical.atomical_id] = outputs;
+      for (const [key, value] of Object.entries(outputs)) {
+        let atomical_value: number = value as number;
+        if (atomical_value < 546 && atomical_value > 0) {
+          atomical_value = 546
+        }
+        if (atomical_value == 0) {
+          continue
+        }
+        atomicalBuilder.addOutput({
+          address: inputUtxoPartial.address,
+          value: atomical_value
+        });
+        index += 1;
+      }
+    }
+    await atomicalBuilder.setData(atomicalsToColored);
+    console.log(atomicalBuilder);
+    await this.promptContinue();
+    const result = await atomicalBuilder.start(this.funding.WIF);
+    return {
+      success: true,
+      data: result
+    }
+  }
+
+  async promptCustomColored(index, availableBalance): Promise<{}> {
+    let remainingBalance = availableBalance;
+    const atomicalColored = {};
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+
+    try {
+      const prompt = (query) => new Promise((resolve) => rl.question(query, resolve));
+      while (remainingBalance > 0) {
+        console.log('-')
+        console.log(`Remaining amount: ${remainingBalance}`)
+
+        const prompt = (query) => new Promise((resolve) => rl.question(query, resolve));
+        let reply = (await prompt("Current outputs uxto index is " + index + ", Please enter amount you want to separated: ") as any);
+
+        console.log('--------');
+        if (reply === 'f') {
+          break;
+        }
+        const valuePart = parseInt(reply, 10);
+
+        if (valuePart < 0 || !valuePart) {
+          console.log('Invalid value, minimum: 1')
+          continue;
+        }
+
+        if (remainingBalance - valuePart < 0) {
+          console.log('Invalid value, maximum remaining: ' + remainingBalance);
+          continue;
+        }
+
+        atomicalColored[index] = valuePart;
+        remainingBalance -= valuePart;
+        index += 1;
+      }
+      if (remainingBalance > 0) {
+        throw new Error('Remaining balance was not 0')
+      }
+      console.log('Successfully allocated entire available amounts to recipients...')
+      return atomicalColored;
+    } finally {
+      rl.close();
+    }
+  }
+
+  async promptContinue() {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+
+    try {
+      let reply: string = '';
+      const prompt = (query) => new Promise((resolve) => rl.question(query, resolve));
+
+      reply = (await prompt("Does everything look good above? To continue type 'y' or 'yes': ") as any);
+
+      if (reply === 'y' || reply === 'yes') {
+        return;
+      }
+      throw 'Aborted';
+    } finally {
+      rl.close();
+    }
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -79,6 +79,7 @@ import { DecodeTxCommand } from "./commands/decode-tx-command";
 import { AwaitUtxoCommand } from "./commands/await-utxo-command";
 import { InitInteractiveInfiniteDftCommand } from "./commands/init-interactive-infinite-dft-command";
 import { InitInteractiveFixedDftCommand } from "./commands/init-interactive-fixed-dft-command";
+import { customColorInteractiveCommand } from "./commands/custom-color-interactive-command";
 export { decorateAtomicals } from "./utils/atomical-format-helpers";
 export { addressToP2PKH } from "./utils/address-helpers";
 export { getExtendTaprootAddressKeypairPath } from "./utils/address-keypair-path";
@@ -617,6 +618,23 @@ export class Atomicals implements APIInterface {
       this.electrumApi.close();
     }
   }
+
+  async customColorItneractive(options: BaseRequestOptions, atomicalId: string, funding: IWalletRecord, atomicalOwner: IWalletRecord): Promise<CommandResultInterface> {
+    try {
+      await this.electrumApi.open();
+      const command: CommandInterface = new customColorInteractiveCommand(this.electrumApi, options, atomicalId, atomicalOwner, funding);
+      return await command.run();
+    } catch (error: any) {
+      return {
+        success: false,
+        message: error.toString(),
+        error
+      }
+    } finally {
+      this.electrumApi.close();
+    }
+  }
+  
   async emitInteractive(options: BaseRequestOptions, atomicalId: string, files: string[], funding: IWalletRecord, atomicalOwner: IWalletRecord): Promise<CommandResultInterface> {
     try {
       await this.electrumApi.open();

--- a/lib/utils/atomical-operation-builder.ts
+++ b/lib/utils/atomical-operation-builder.ts
@@ -186,7 +186,8 @@ export interface AtomicalOperationBuilderOptions {
         | "evt"
         | "sl"
         | "x"
-        | "y";
+        | "y"
+        | "z";
     requestContainerMembership?: string;
     bitworkc?: string;
     bitworkr?: string;

--- a/lib/utils/miner-worker.ts
+++ b/lib/utils/miner-worker.ts
@@ -288,6 +288,7 @@ export const workerPrepareCommitRevealConfig = (
         | "sl"
         | "x"
         | "y"
+        | "z"
         | "mod"
         | "evt"
         | "dat",
@@ -339,6 +340,7 @@ export const appendMintUpdateRevealScript = (
         | "sl"
         | "x"
         | "y"
+        | "z"
         | "mod"
         | "evt"
         | "dat",


### PR DESCRIPTION
Add a custom color command:

Like this:

```
➜  atomicals-js git:(custom-color) ✗ npm run cli custom-color f913034127a804de763c08deaeb617fcf2b44e88c9f9259027966812fddf3e63i0 --satsbyte 50

> atomicals-js@0.1.77 cli
> node dist/cli.js custom-color f913034127a804de763c08deaeb617fcf2b44e88c9f9259027966812fddf3e63i0 50

walletPath ./wallets/wallet.json
====================================================================
Custom color FTs Interactive
====================================================================
-
Remaining amount: 1000
Current outputs uxto index is 0, Please enter amount you want to separated:
--------
Invalid value, minimum: 1
-
Remaining amount: 1000
Current outputs uxto index is 0, Please enter amount you want to separated: 1000
--------
Successfully allocated entire available amounts to recipients...
-
Remaining amount: 1000
Current outputs uxto index is 1, Please enter amount you want to separated: 100
--------
-
Remaining amount: 900
Current outputs uxto index is 2, Please enter amount you want to separated: 900
--------
Successfully allocated entire available amounts to recipients...
AtomicalOperationBuilder {
  options: {
    electrumApi: ElectrumApi {
      baseUrl: 'http://0.0.0.0:5001/proxy',
      usePost: true,
      isOpenFlag: true,
      endpoints: [Array]
    },
    rbf: undefined,
    satsbyte: 15,
    address: 'tb1pmx6g0r5ezhyvxu2fjs4syypwmphyvtj87e6fgfy99hz2lz24russwxgcz6',
    disableMiningChalk: undefined,
    opType: 'z',
    skipOptions: {},
    meta: undefined,
    ctx: undefined,
    init: undefined
  },
  userDefinedData: {
    '6787f39b5d2fc020eb0f8e68cd925f297065c5c82c86d175cce1a9beaa411239i0': { '0': 1000 },
    '9527efa43262636d8f5917fc763fbdd09333e4b387afd6d4ed7a905a127b27b4i0': { '1': 100, '2': 900 }
  },
  containerMembership: null,
  bitworkInfoCommit: null,
  bitworkInfoReveal: null,
  requestName: null,
  requestParentId: null,
  requestNameType: 'NONE',
  meta: {},
  args: {},
  init: {},
  ctx: {},
  parentInputAtomical: null,
  inputUtxos: [ { utxo: [Object], keypairInfo: [Object] } ],
  additionalOutputs: [
    {
      address: 'tb1pmx6g0r5ezhyvxu2fjs4syypwmphyvtj87e6fgfy99hz2lz24russwxgcz6',
      value: 1000
    },
    {
      address: 'tb1pmx6g0r5ezhyvxu2fjs4syypwmphyvtj87e6fgfy99hz2lz24russwxgcz6',
      value: 546
    },
    {
      address: 'tb1pmx6g0r5ezhyvxu2fjs4syypwmphyvtj87e6fgfy99hz2lz24russwxgcz6',
      value: 900
    }
  ]
}
Does everything look good above? To continue type 'y' or 'yes': yes
satsbyte fee manually set to:  15
copiedData {
  '6787f39b5d2fc020eb0f8e68cd925f297065c5c82c86d175cce1a9beaa411239i0': { '0': 1000 },
  '9527efa43262636d8f5917fc763fbdd09333e4b387afd6d4ed7a905a127b27b4i0': { '1': 100, '2': 900 }
}
Payload CBOR Size (bytes):  153
Payload Encoded:  {
  '6787f39b5d2fc020eb0f8e68cd925f297065c5c82c86d175cce1a9beaa411239i0': { '0': 1000 },
  '9527efa43262636d8f5917fc763fbdd09333e4b387afd6d4ed7a905a127b27b4i0': { '1': 100, '2': 900 }
}
```