### PR TITLE
Fix get_realm_info calls according to the changes of Server 1.5.1.0

### DIFF
--- a/lib/api/electrum-api.ts
+++ b/lib/api/electrum-api.ts
@@ -254,7 +254,7 @@ export class ElectrumApi implements ElectrumApiInterface {
     }
 
     public atomicalsGetRealmInfo(realmOrSubRealm: string, verbose?: boolean): Promise<any> {
-        return this.call('blockchain.atomicals.get_realm_info', [realmOrSubRealm, verbose ? 1 : 0]);
+        return this.call('blockchain.atomicals.get_realm_info', [realmOrSubRealm]);
     }
 
     public atomicalsGetByRealm(realm: string): Promise<any> {


### PR DESCRIPTION
Fix get_realm_info calls according to the changes made by the ElectrumX server.